### PR TITLE
Add subscribers count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .vscode
 .venv
 *.csv
-*.xlsx
+*.xlsx*

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+force_single_line=True

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,515 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=4
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=missing-docstring,
+    missing-module-docstring,
+    useless-object-inheritance,
+
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=colorized
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=LF
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=snake_case
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           fd,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception,
+                       StandardError

--- a/.style.yapf
+++ b/.style.yapf
@@ -17,8 +17,9 @@ based_on_style=google
 #       end_ts=now(),
 #   )        # <--- this bracket is dedented and on a separate line
 dedent_closing_brackets=True
+coalesce_brackets=True
 
-# Split before arguments, but do not split all subexpressions recursively
+# Split before arguments, but do not split all sub expressions recursively
 # (unless needed).
 split_all_top_level_comma_separated_values=True
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ make setup
 ```
 
 To configure the parameters, that should be extracted for the repos of your organization, adapt the
-lists `PRIMARY_PARAMS` and `SECONDARY_PARAMS` in `main()`.
+lists `primary_params` and `secondary_params` in `main()`.
 
-- `PRIMARY_PARAMS` in this context are parameters, whose values are directly contained in the JSON
+- `primary_params` in this context are parameters, whose values are directly contained in the JSON
 response of `https://api.github.com/orgs/ORGANIZATION_NAME/repos`.
-- `SECONDARY_PARAMS` are those, for which no value is given in the JSON, but instead a url, which
+- `secondary_params` are those, for which no value is given in the JSON, but instead a url, which
 can be queried, e.g. `subscribers_url`. The length of the list returned when querying this URL will
 represent the count of `subscribers` in this case.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ python3 fetch_stats.py YOUR_GITHUB_TOKEN YOUR_ORGANIZATION_NAME --public_only --
 If `-p` or `--skip_private` is set, private repos of the organization will be skipped. The default
 value is `False`, i.e. private repositories will be included by default.
 
-Likewise, if `-n` or `--skip_archived` is set, archived repos of the organization will be skipped.
-The default is `false`, i.e. archived repositories will be included by dedault.
+Likewise, if `-a` or `--skip_archived` is set, archived repos of the organization will be skipped.
+The default is `false`, i.e. archived repositories will be included by default.
 
-The fetched stats will be written to a file `ORGANIZATION_NAME_stats.csv` including a header.
+The fetched stats will be written to a file `YOUR_ORGANIZATION_NAME_stats.csv` including a header.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ lists `primary_params` and `secondary_params` in `main()`.
 
 - `primary_params` in this context are parameters, whose values are directly contained in the JSON
 response of `https://api.github.com/orgs/ORGANIZATION_NAME/repos`.
-- `secondary_params` are those, for which no value is given in the JSON, but instead a url, which
-can be queried, e.g. `subscribers_url`. The length of the list returned when querying this URL will
+- `secondary_params` are some of those, for which no value is given in the JSON, but instead a url, which
+can be queried. Only tested so far with `subscribers_url`. The length of the list returned when querying this URL will
 represent the count of `subscribers` in this case.
 
 Initially I was not sure, why `stargazers_count` and `watchers_count` had the same numbers, and the

--- a/README.md
+++ b/README.md
@@ -1,18 +1,51 @@
 # GitHubOrgStats
 
-This is a simply and not fully tested script to extract some stats for a github organization, such
+This is a simple and not fully tested script to extract some stats for a github organization, such
 as number of stars, watchers, forks, etc.
 It will store the results in a .csv file, which can be imported in spread sheets for visualisation.
+:warning: The script has not been fully tested and comes without any warranties. Use at your own
+risk.
 
-The script has not been fully tested and comes without any warranties. Use at your own risk.
+## Initial setup
 
-Usage:
+To install the necessary dependencies (assuming you already have pipenv and Python 3.9 installed),
+run:
+
+```bash
+make setup
+```
+
+To configure the parameters, that should be extracted for the repos of your organization, adapt the
+lists `DIRECT_PARAMS` and `INDIRECT_PARAMS` in `main()`.
+
+- `DIRECT_PARAMS` in this context are parameters, whose values are directly contained in the JSON
+response of `https://api.github.com/orgs/ORGANIZATION_NAME/repos`.
+- `INDIRECT_PARAMETERS` are those, for which no value is given in the JSON, but instead a url, which
+can be queried, e.g. `subscribers_url`. The length of the list returned when querying this URL will
+represent the count of `subscribers` in this case.
+
+Initially I was not sure, why `stargazers_count` and `watchers_count` had the same numbers, and the
+number of `watchers` did not seem to be correct. The documentation on this clarified things:
+https://docs.github.com/en/rest/activity/starring?apiVersion=2022-11-28#starring-versus-watching :wink:
+
+## Usage
+
+The script must be called with as in the following:
 
 ```bash
 python3 fetch_stats.py YOUR_GITHUB_TOKEN YOUR_ORGANIZATION_NAME
 ```
 
-It will store the results in a .csv file with headers:
-`id, name, full_name, private, stargazers_count, watchers_count, forks_count`
+There are two optional flags, which can be set:
 
-To install all necessary dependencies and a venv for this project, run `make setup` initially.
+```bash
+python3 fetch_stats.py YOUR_GITHUB_TOKEN YOUR_ORGANIZATION_NAME --public_only --non_archived_only
+```
+
+If `-p` or `--skip_private` is set, private repos of the organization will be skipped. The default
+value is `False`, i.e. private repositories will be included by default.
+
+Likewise, if `-n` or `--skip_archived` is set, archived repos of the organization will be skipped.
+The default is `false`, i.e. archived repositories will be included by dedault.
+
+The fetched stats will be written to a file `ORGANIZATION_NAME_stats.csv` including a header.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # GitHubOrgStats
 
-This is a simple and not fully tested script to extract some stats for a github organization, such
-as number of stars, watchers, forks, etc.
+This is a simple and not fully tested script to extract some statistics for all repositories
+belonging to a github organization, such as number of stars, watchers, forks, etc.
+(Private or archived repositories can optionally be skipped).
 It will store the results in a .csv file, which can be imported in spread sheets for visualisation.
 :warning: The script has not been fully tested and comes without any warranties. Use at your own
 risk.
@@ -16,11 +17,11 @@ make setup
 ```
 
 To configure the parameters, that should be extracted for the repos of your organization, adapt the
-lists `DIRECT_PARAMS` and `INDIRECT_PARAMS` in `main()`.
+lists `PRIMARY_PARAMS` and `SECONDARY_PARAMS` in `main()`.
 
-- `DIRECT_PARAMS` in this context are parameters, whose values are directly contained in the JSON
+- `PRIMARY_PARAMS` in this context are parameters, whose values are directly contained in the JSON
 response of `https://api.github.com/orgs/ORGANIZATION_NAME/repos`.
-- `INDIRECT_PARAMETERS` are those, for which no value is given in the JSON, but instead a url, which
+- `SECONDARY_PARAMS` are those, for which no value is given in the JSON, but instead a url, which
 can be queried, e.g. `subscribers_url`. The length of the list returned when querying this URL will
 represent the count of `subscribers` in this case.
 

--- a/fetch_stats.py
+++ b/fetch_stats.py
@@ -81,16 +81,16 @@ class OrgStats:
         for repo in page:
             self.processed += 1
             if self.args.skip_private and repo["private"]:
-                print(f"Skipping private repo: {repo['name']}", end="\r")
+                print(f"Skipping private repo: {repo['name']}", " " * 30, end="\r")
                 self.skipped_private += 1
                 continue
 
             if self.args.skip_archived and repo["archived"]:
-                print(f"Skipping archived repo: {repo['name']}", end="\r")
+                print(f"Skipping archived repo: {repo['name']}", " " * 30, end="\r")
                 self.skipped_archived += 1
                 continue
 
-            print(f"Processing repository: {repo['name']}", end="\r")
+            print(f"Processing repository: {repo['name']}", " " * 30, end="\r")
             repo_data = {}
             for param in self.direct_params:
                 repo_data[param] = repo[param]

--- a/fetch_stats.py
+++ b/fetch_stats.py
@@ -1,33 +1,168 @@
 import argparse
 import csv
 import json
+from urllib.parse import parse_qs, urlparse
 
 import requests
 
 
 class OrgStats:
 
-    def __init__(self):
+    def __init__(self, args, direct_params, indirect_params):
+        self.args = args
+        self.org = self.args.organization
+        self.headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self.args.github_token}",
+            "X-GitHub-Api-Version": "2022-11-28"
+        }
+        print("*"*10, self.args)
+        self.direct_params = direct_params
+        self.indirect_params = indirect_params
+        self.skipped_private = 0
+        self.skipped_archived = 0
+        self.processed = 0
         self.repo_list = []
 
-    def read_page_stats(self, resp_json):
-        for repo in resp_json:
+    def read_stats(self):
+        '''Reads the paginated stats for all pages for all repos and calls internal methods to
+        store the data for later output.
+
+        Raises:
+            HTTPError:
+                In case of exceptions when querying the GitHub API.
+        '''
+
+        print(
+            f'Fetching statistics for '\
+                f'{"public and private" if not self.args.skip_private else "only the public"}' \
+                f' repositories of {self.org}. Archived repositories will be ' \
+                    f'{"skipped" if self.args.skip_archived else "included"}...'
+        )
+        last_page = False
+        page = 1
+        while not last_page:
+            try:
+                response = requests.get(
+                    f"https://api.github.com/orgs/{self.org}/repos?per_page=100&page={page}",
+                    headers=self.headers,
+                    timeout=10
+                )
+                response.raise_for_status()
+            except requests.exceptions.HTTPError as e:
+                print("Something went wrong, details: " + str(e))
+
+            resp_json = json.loads(response.content)
+            self._read_stats_page(resp_json)
+            page += 1
+            if "link" in response.headers and not "next" in response.headers["link"]:
+                last_page = True
+            if not "link" in response.headers:
+                last_page = True
+
+        print(f"Processed {self.processed} repos in total. " \
+              f"Skipped {self.skipped_private} private and {self.skipped_archived } " \
+              "archived repos.")
+
+    def _read_stats_page(self, page):
+        '''Reads the stats for all repos on the passed page and stores the defined params in
+        self.repo_list for later output"
+
+        Args:
+           page: str (JSON)
+                JSON of the passed page to be processed
+        '''
+
+        for repo in page:
+            self.processed += 1
+            if self.args.skip_private and repo["private"]:
+                print(f"Skipping private repo: {repo['name']}", end="\r")
+                self.skipped_private += 1
+                continue
+
+            if self.args.skip_archived and repo["archived"]:
+                print(f"Skipping archived repo: {repo['name']}", end="\r")
+                self.skipped_archived += 1
+                continue
+
+            print(f"Processing repository: {repo['name']}", end="\r")
             repo_data = {}
-            repo_data["id"] = repo["id"]
-            repo_data["name"] = repo["name"]
-            repo_data["full_name"] = repo["full_name"]
-            repo_data["private"] = repo["private"]
-            repo_data["stargazers_count"] = repo["stargazers_count"]
-            repo_data["watchers_count"] = repo["watchers_count"]
-            repo_data["forks_count"] = repo["forks_count"]
+            for param in self.direct_params:
+                repo_data[param] = repo[param]
+
+            for param in self.indirect_params:
+                repo_data[param] = self._get_indirect_param_count(repo[f"{param}_url"])
 
             self.repo_list.append(repo_data)
 
-    def write_csv(self, filename="org_stats.csv"):
-        with open(filename, 'w', newline='') as stats_file:
+    def write_csv(self):
+        '''Writes self.repo_list a .csv file."
+        '''
+        with open(f"{self.org}_stats.csv", 'w', newline='') as stats_file:
             writer = csv.DictWriter(stats_file, self.repo_list[0].keys())
             writer.writeheader()
             writer.writerows(self.repo_list)
+
+    def _get_indirect_param_count(self, param_url):
+        '''Calculated the count for a parameter, which is not already directly included in the
+        response of https://api.github.com/orgs/{self.org}/.
+        For those parameters, a url is given, which needs to be requested and the number elements
+        of the returned list of the paginated response represent the counter for this parameter.
+
+        Args:
+           param_url: str
+                JSON of the passed page to be processed
+
+        Returns:
+            The counter for the given parameter
+
+        Raises:
+            HTTPError:
+                In case of exceptions when querying the GitHub API.
+        '''
+
+        try:
+            response = requests.head(f"{param_url}?per_page=1", headers=self.headers, timeout=10)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print("Something went wrong, details: " + str(e))
+
+        if "link" in response.headers:
+            number = self._get_last_link_number(response.headers["link"])
+            if number:
+                return number
+
+        try:
+            response = requests.get(param_url, headers=self.headers, timeout=10)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print("Something went wrong, details: " + str(e))
+
+        resp_json = json.loads(response.content)
+        return len(resp_json)
+
+    def _get_last_link_number(self, link_header):
+        '''Get the number of the link in the link header with rel=last.
+        If no "last" link is found, None will be returned.
+
+        Args:
+           link_header: str
+                value of the link header
+
+        Returns:
+            The number of the last link | None in case the "last" link does not
+            exist.
+        '''
+
+        links = link_header.split(",")
+
+        for link in links:
+            if "last" in link:
+                link = link.rsplit(";")[0]
+                link = link.replace("<", "")
+                link = link.replace(">", "")
+                return parse_qs(urlparse(link).query)["page"][0]
+            return None
 
 
 def get_args():
@@ -42,6 +177,12 @@ def get_args():
     )
     parser.add_argument("github_token", help="your personal github token.")
     parser.add_argument("organization", help="name of the github organization.")
+    parser.add_argument("-p", "--skip_private", help="if set, private repos of the organization" \
+        "will be skipped. Default: False, i.e. private repos will be included.",
+        action="store_true", default=False)
+    parser.add_argument("-a", "--skip_archived", help="if set, archived repos of the organization " \
+        "will be skipped. Default: False, i.,e. archived repos will be included." \
+            "repos.", action="store_true", default=False)
     args = parser.parse_args()
 
     return args
@@ -49,35 +190,14 @@ def get_args():
 
 def main():
     args = get_args()
-    token = args.github_token
-    org = args.organization
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "Authorization": f"Bearer {token}",
-        "X-GitHub-Api-Version": "2022-11-28"
-    }
+    DIRECT_PARAMS = [
+        "id", "name", "full_name", "private", "archived", "stargazers_count", "forks_count"
+    ]
+    INDIRECT_PARAMS = ["subscribers"]  # those, that appear with a "_url" suffix in the JSON of
+    # https://api.github.com/users/ORGANIZATION_NAME/repos
 
-    org_stats = OrgStats()
-
-    last_page = False
-    page = 1
-    while not last_page:
-        try:
-            response = requests.get(
-                f"https://api.github.com/orgs/{org}/repos?per_page=100&page={page}",
-                headers=headers,
-                timeout=10
-            )
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            print("Something went wrong, details: " + str(e))
-
-        resp_json = json.loads(response.content)
-        org_stats.read_page_stats(resp_json)
-        page += 1
-        if not "next" in response.headers["link"]:
-            last_page = True
-
+    org_stats = OrgStats(args, DIRECT_PARAMS, INDIRECT_PARAMS)
+    org_stats.read_stats()
     org_stats.write_csv()
 
 

--- a/fetch_stats.py
+++ b/fetch_stats.py
@@ -16,7 +16,6 @@ class OrgStats:
             "Authorization": f"Bearer {self.args.github_token}",
             "X-GitHub-Api-Version": "2022-11-28"
         }
-        print("*"*10, self.args)
         self.direct_params = direct_params
         self.indirect_params = indirect_params
         self.skipped_private = 0

--- a/fetch_stats.py
+++ b/fetch_stats.py
@@ -57,7 +57,7 @@ class OrgStats:
             page += 1
             # As the response might be paginated, repeating this until reaching the last page.
             # I assume, that the last page should not have a "next" in the link header or no link
-            # header is present at all, probably if the response is not pagineted.
+            # header is present at all, probably if the response is not paginated.
             # Some docu on pagination in GitHub API:
             # https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28
             if "link" in response.headers and not "next" in response.headers["link"]:
@@ -96,7 +96,7 @@ class OrgStats:
                 repo_data[param] = repo[param]
 
             for param in self.secondary_params:
-                repo_data[param] = self._get_indirect_param_count(repo[f"{param}_url"])
+                repo_data[param] = self._get_secondary_param_count(repo[f"{param}_url"])
 
             self.repo_list.append(repo_data)
 
@@ -108,7 +108,7 @@ class OrgStats:
             writer.writeheader()
             writer.writerows(self.repo_list)
 
-    def _get_indirect_param_count(self, param_url):
+    def _get_secondary_param_count(self, param_url):
         '''Calculated the count for a parameter, which is not already directly included in the
         response of https://api.github.com/orgs/{self.org}/.
         For those parameters, a url is given, which needs to be requested and the number elements

--- a/fetch_stats.py
+++ b/fetch_stats.py
@@ -8,7 +8,7 @@ import requests
 
 class OrgStats:
 
-    def __init__(self, args, direct_params, indirect_params):
+    def __init__(self, args, primary_params, secondary_params):
         self.args = args
         self.org = self.args.organization
         self.headers = {
@@ -16,8 +16,8 @@ class OrgStats:
             "Authorization": f"Bearer {self.args.github_token}",
             "X-GitHub-Api-Version": "2022-11-28"
         }
-        self.direct_params = direct_params
-        self.indirect_params = indirect_params
+        self.primary_params = primary_params
+        self.secondary_params = secondary_params
         self.skipped_private = 0
         self.skipped_archived = 0
         self.processed = 0
@@ -92,10 +92,10 @@ class OrgStats:
 
             print(f"Processing repository: {repo['name']}", " " * 30, end="\r")
             repo_data = {}
-            for param in self.direct_params:
+            for param in self.primary_params:
                 repo_data[param] = repo[param]
 
-            for param in self.indirect_params:
+            for param in self.secondary_params:
                 repo_data[param] = self._get_indirect_param_count(repo[f"{param}_url"])
 
             self.repo_list.append(repo_data)
@@ -206,13 +206,13 @@ def get_args():
 
 def main():
     args = get_args()
-    DIRECT_PARAMS = [
+    PRIMARY_PARAMS = [
         "id", "name", "full_name", "private", "archived", "stargazers_count", "forks_count"
     ]
-    INDIRECT_PARAMS = ["subscribers"]  # those, that appear with a "_url" suffix in the JSON of
+    SECONDARY_PARAMS = ["subscribers"]  # those, that appear with a "_url" suffix in the JSON of
     # https://api.github.com/users/ORGANIZATION_NAME/repos
 
-    org_stats = OrgStats(args, DIRECT_PARAMS, INDIRECT_PARAMS)
+    org_stats = OrgStats(args, PRIMARY_PARAMS, SECONDARY_PARAMS)
     org_stats.read_stats()
     org_stats.write_csv()
 

--- a/fetch_stats.py
+++ b/fetch_stats.py
@@ -215,7 +215,8 @@ def main():
     primary_params = [
         "id", "name", "full_name", "private", "archived", "stargazers_count", "forks_count"
     ]
-    secondary_params = ["subscribers"]  # those, that appear with a "_url" suffix in the JSON of
+    secondary_params = ["subscribers"]  # some of those (only tested with "subscribers" so far),
+    # that appear with a "_url" suffix in the JSON response of
     # https://api.github.com/users/ORGANIZATION_NAME/repos
 
     org_stats = OrgStats(args, primary_params, secondary_params)


### PR DESCRIPTION
* added some more comments and docu in the README.md
* added option for skipping private and archived repos
* added option to include "indirect parameters", which are those that are not already included in `https://api.github.com/orgs/ORGANIZATION_NAME/repos`, but for which rather a URL is returned, which needs to be queried, such as `subscribers_url`.

- [ ] In a next PR, I could also add a count for internal/external contributors